### PR TITLE
remove babel-register

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
   },
   "devDependencies": {
     "babel-cli": "^6.26.0",
-    "babel-register": "^6.26.0",
     "babel-preset-env": "^1.6.1",
     "jasmine-console-reporter": "^2.0.1"
   }

--- a/spec/run.js
+++ b/spec/run.js
@@ -1,8 +1,3 @@
-require('babel-register')({
-    // This will override `node_modules` ignoring - you can alternatively pass
-    // an array of strings to be explicitly matched or a regex / glob
-    ignore: false 
-  });
 const Jasmine = require('jasmine');
 
 var jasmine = new Jasmine();


### PR DESCRIPTION
This PR cannot be merged until the new version of the `@cumulus/integration-tests` with babel support is released