### PR TITLE
Update test-cumulus stack name

### DIFF
--- a/app/config.yml
+++ b/app/config.yml
@@ -1,7 +1,7 @@
 
 default:
-  stackName: test-cumulus-intg
-  stackNameNoDash: TestCumulusIntg
+  stackName: test-cumulus-integration
+  stackNameNoDash: TestCumulusIntegration
 
   apiStage: dev
 

--- a/app/config.yml
+++ b/app/config.yml
@@ -1,7 +1,7 @@
 
 default:
-  stackName: test-cumulus
-  stackNameNoDash: TestCumulus
+  stackName: test-cumulus-intg
+  stackNameNoDash: TestCumulusIntg
 
   apiStage: dev
 

--- a/deployer/config.yml
+++ b/deployer/config.yml
@@ -1,6 +1,6 @@
 default:
-  prefix: test-cumulus-intg
-  stackName: test-cumulus-intg-deployer
+  prefix: test-cumulus-integration
+  stackName: test-cumulus-integration-deployer
   stackNameNoDash: testCumulusIntgDeployer
   buckets:
     internal: cumulus-test-sandbox-internal

--- a/deployer/config.yml
+++ b/deployer/config.yml
@@ -1,7 +1,7 @@
 default:
-  prefix: test-cumulus
-  stackName: test-cumulus-deployer
-  stackNameNoDash: testCumulus
+  prefix: test-cumulus-intg
+  stackName: test-cumulus-intg-deployer
+  stackNameNoDash: testCumulusIntgDeployer
   buckets:
     internal: cumulus-test-sandbox-internal
   capabilities:

--- a/iam/config.yml
+++ b/iam/config.yml
@@ -1,6 +1,6 @@
 default:
-  prefix: test-cumulus
-  stackName: test-cumulus-iam
+  prefix: test-cumulus-intg
+  stackName: test-cumulus-intg-iam
   authorizor: false
   capabilities:
     - CAPABILITY_NAMED_IAM

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     ]
   },
   "dependencies": {
-    "@cumulus/api": "1.1.3",
+    "@cumulus/api": "^1.1.3",
     "@cumulus/deployment": "^1.1.3",
     "@cumulus/discover-pdrs": "^1.1.3",
     "@cumulus/hello-world": "^1.1.3",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     ]
   },
   "dependencies": {
-    "@cumulus/api": "^1.1.3",
+    "@cumulus/api": "../cumulus/packages/api",
     "@cumulus/deployment": "^1.1.3",
     "@cumulus/discover-pdrs": "^1.1.3",
     "@cumulus/hello-world": "^1.1.3",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     ]
   },
   "dependencies": {
-    "@cumulus/api": "../cumulus/packages/api",
+    "@cumulus/api": "1.1.3",
     "@cumulus/deployment": "^1.1.3",
     "@cumulus/discover-pdrs": "^1.1.3",
     "@cumulus/hello-world": "^1.1.3",

--- a/spec/config.yml
+++ b/spec/config.yml
@@ -1,16 +1,16 @@
-stackName: test-cumulus
+stackName: test-cumulus-intg
 bucket: cumulus-test-sandbox-internal
 DiscoverAndQueuePdrs: &defaults
   meta:
-    stack: test-cumulus
+    stack: test-cumulus-intg
     buckets:
       internal: cumulus-test-sandbox-internal
       private: cumulus-test-sandbox-private
     templates:
-      ParsePdr: s3://cumulus-test-sandbox-internal/test-cumulus/workflows/ParsePdr.json
-      IngestGranule: s3://cumulus-test-sandbox-internal/test-cumulus/workflows/IngestGranule.json
+      ParsePdr: s3://cumulus-test-sandbox-internal/test-cumulus-intg/workflows/ParsePdr.json
+      IngestGranule: s3://cumulus-test-sandbox-internal/test-cumulus-intg/workflows/IngestGranule.json
     queues:
-      startSF: https://sqs.us-east-1.amazonaws.com/{{AWS_ACCOUNT_ID}}/test-cumulus-startSF
+      startSF: https://sqs.us-east-1.amazonaws.com/{{AWS_ACCOUNT_ID}}/test-cumulus-intg-startSF
 ParsePdr: *defaults
 IngestGranule:
   <<: *defaults

--- a/spec/config.yml
+++ b/spec/config.yml
@@ -1,16 +1,16 @@
-stackName: test-cumulus-intg
+stackName: test-cumulus-integration
 bucket: cumulus-test-sandbox-internal
 DiscoverAndQueuePdrs: &defaults
   meta:
-    stack: test-cumulus-intg
+    stack: test-cumulus-integration
     buckets:
       internal: cumulus-test-sandbox-internal
       private: cumulus-test-sandbox-private
     templates:
-      ParsePdr: s3://cumulus-test-sandbox-internal/test-cumulus-intg/workflows/ParsePdr.json
-      IngestGranule: s3://cumulus-test-sandbox-internal/test-cumulus-intg/workflows/IngestGranule.json
+      ParsePdr: s3://cumulus-test-sandbox-internal/test-cumulus-integration/workflows/ParsePdr.json
+      IngestGranule: s3://cumulus-test-sandbox-internal/test-cumulus-integration/workflows/IngestGranule.json
     queues:
-      startSF: https://sqs.us-east-1.amazonaws.com/{{AWS_ACCOUNT_ID}}/test-cumulus-intg-startSF
+      startSF: https://sqs.us-east-1.amazonaws.com/{{AWS_ACCOUNT_ID}}/test-cumulus-integration-startSF
 ParsePdr: *defaults
 IngestGranule:
   <<: *defaults


### PR DESCRIPTION
The `test-cumulus` stack is currently in a bad state. It was having a KMS key error for all it's lambda functions and now the `test-cumulus` stack is failing to update or delete. I've created a new test stack with the prefix `test-cumulus-intg` and opening this PR to use it a back up solution so we can move forward with releasing `1.1.5`.

Current cumulus integration tests running on the [circleci project](https://circleci.com/gh/cumulus-nasa/cumulus/1564) for [cumulus](https://github.com/cumulus-nasa/cumulus) is using this branch.